### PR TITLE
Specify int variant for 32-bit MCU

### DIFF
--- a/src/PMW3360.cpp
+++ b/src/PMW3360.cpp
@@ -436,8 +436,8 @@ PMW3360_DATA PMW3360::readBurst()
 
   PMW3360_DATA data;
 
-  bool motion = (burstBuffer[0] & 0x80) != 0;
-  bool surface = (burstBuffer[0] & 0x08) == 0;   // 0 if on surface / 1 if off surface
+  data.isMotion = (burstBuffer[0] & 0x80) != 0;
+  data.isOnSurface = (burstBuffer[0] & 0x08) == 0;   // 0 if on surface / 1 if off surface
 
   uint8_t xl = burstBuffer[2];    // dx LSB
   uint8_t xh = burstBuffer[3];    // dx MSB
@@ -446,19 +446,14 @@ PMW3360_DATA PMW3360::readBurst()
   uint8_t sl = burstBuffer[10];   // shutter LSB
   uint8_t sh = burstBuffer[11];   // shutter MSB
   
-  int16_t x = xh<<8 | xl;
-  int16_t y = yh<<8 | yl;
-  unsigned int shutter = sh<<8 | sl;
+  data.dx = xh<<8 | xl;
+  data.dy = yh<<8 | yl;
+  data.shutter = sh<<8 | sl;
 
-  data.isMotion = motion;
-  data.isOnSurface = surface;
-  data.dx = x;
-  data.dy = y;
   data.SQUAL = burstBuffer[6];
   data.rawDataSum = burstBuffer[7];
   data.maxRawData = burstBuffer[8];
   data.minRawData = burstBuffer[9];
-  data.shutter = shutter;
 
   return data;
 }

--- a/src/PMW3360.cpp
+++ b/src/PMW3360.cpp
@@ -446,8 +446,8 @@ PMW3360_DATA PMW3360::readBurst()
   uint8_t sl = burstBuffer[10];   // shutter LSB
   uint8_t sh = burstBuffer[11];   // shutter MSB
   
-  int x = xh<<8 | xl;
-  int y = yh<<8 | yl;
+  int16_t x = xh<<8 | xl;
+  int16_t y = yh<<8 | yl;
   unsigned int shutter = sh<<8 | sl;
 
   data.isMotion = motion;

--- a/src/PMW3360.h
+++ b/src/PMW3360.h
@@ -116,8 +116,8 @@ struct PMW3360_DATA
 {
  bool isMotion;        // True if a motion is detected. 
  bool isOnSurface;     // True when a chip is on a surface 
- int dx;               // displacement on x directions. Unit: Count. (CPI * Count = Inch value)
- int dy;               // displacement on y directions.
+ int16_t dx;           // displacement on x directions. Unit: Count. (CPI * Count = Inch value)
+ int16_t dy;           // displacement on y directions.
  byte SQUAL;           // Surface Quality register, max 0x80. Number of features on the surface = SQUAL * 8
  byte rawDataSum;      // It reports the upper byte of an 18‐bit counter which sums all 1296 raw data in the current frame; * Avg value = Raw_Data_Sum * 1024 / 1296
  byte maxRawData;      // Max raw data value in current frame, max=127


### PR DESCRIPTION
Using `int` for motion values on 32-bit microcontrollers leads to problems as negative values will be converted into high positive values. To address that issue I specified the values as `int16_t`.

Additionally, I removed some unnecessary variables and  stored the data directly into the struct.